### PR TITLE
bug: support persistence from xrp-paychan-shared

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const { createSubmitter } = require('ilp-plugin-xrp-paychan-shared')
 const connectorList = require('./connector_list.json')
 const parentBtpHmacKey = 'parent_btp_uri'
 const rippledList = require('./rippled_list.json')
+const MemoryStore = require('ilp-store-memory')
 const base64url = buf => buf
   .toString('base64')
   .replace(/=/g, '')
@@ -135,6 +136,7 @@ class XrpUplink {
     this.config = config
     this.pluginOpts = config.options
     this.api = null
+    this.store = null // TODO: Make this configurable
     this.subscribed = false
   }
 
@@ -221,8 +223,16 @@ class XrpUplink {
     return this.api
   }
 
+  async _store () {
+    if (!this.store) {
+      this.store = new MemoryStore()
+    }
+    return this.store
+  }
+
   async _submitter () {
     const api = await this._rippleApi()
+    const store = await this._store()
 
     if (!this.subscribed) {
       this.subscribed = true
@@ -232,7 +242,7 @@ class XrpUplink {
       })
     }
 
-    return createSubmitter(api, this.pluginOpts.address, this.pluginOpts.secret)
+    return createSubmitter(api, this.pluginOpts.address, this.pluginOpts.secret, store)
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moneyd-uplink-xrp",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1043,6 +1043,11 @@
         }
       }
     },
+    "ilp-store-memory": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ilp-store-memory/-/ilp-store-memory-1.0.0.tgz",
+      "integrity": "sha512-OxGD//mRTmw2zauj2ZrDvPcozfl8WHJPOgpwrjYc9i+nBxECwIJZKd8JxHAUwf/lQuRAoyY4rxPq0hZ6rpcIvA=="
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moneyd-uplink-xrp",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "ILP provider using XRP payment channels",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "good-table": "^1.0.3",
     "ilp-plugin-xrp-asym-client": "^1.5.3",
     "ilp-plugin-xrp-paychan-shared": "^4.0.1",
+    "ilp-store-memory": "^1.0.0",
     "inquirer": "^6.2.0",
     "moment": "^2.22.2",
     "node-fetch": "^2.2.0",


### PR DESCRIPTION
v4 of `ilp-plugin-xrp-paychan-shared` introduced a new constructor arg which broke the latest release.

This is a quick fix that includes the in-memory store