### PR TITLE
Upgrade uplink to currency scale 9

### DIFF
--- a/connector_list.json
+++ b/connector_list.json
@@ -1,8 +1,10 @@
 {
   "live": [
+    "btp.strata-ilsp-1.com:8079",
+    "btp.strata-ilsp-2.com:8079"
+  ],
+  "old": [
     "btp.connector0.com",
-    "btp.strata-ilsp-1.com",
-    "btp.strata-ilsp-2.com",
     "btp.tinypolarbear.com",
     "btp1.mlab.company",
     "btp2.mlab.company",

--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ async function configure ({ testnet, advanced }) {
     sendRoutes: false,
     receiveRoutes: false,
     options: {
+      currencyScale: 9,
       server: btpServer,
       secret: res.secret,
       address: res.address,

--- a/index.js
+++ b/index.js
@@ -82,12 +82,12 @@ async function configure ({ testnet, advanced }) {
     relation: 'parent',
     plugin: require.resolve('ilp-plugin-xrp-asym-client'),
     assetCode: 'XRP',
-    assetScale: 6,
+    assetScale: 9,
     balance: {
       minimum: '-Infinity',
-      maximum: '20000',
-      settleThreshold: '5000',
-      settleTo: '10000'
+      maximum: '20000000',
+      settleThreshold: '5000000',
+      settleTo: '10000000'
     },
     sendRoutes: false,
     receiveRoutes: false,


### PR DESCRIPTION
**Impetus:** There was severe scale degradation resulting in very high payment fees (>10% sometimes) using an asset scale of 6 with STREAM. This updated uplink config only contains asset scale of 9 for all new clients.