### PR TITLE
feat: report channel details in correct asset scale

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,14 +164,19 @@ class XrpUplink {
       return console.error('No channels found')
     }
 
+    const scale = this.config.assetScale
+
     console.log(table([
       [ chalk.green('index'),
         chalk.green('channel id'),
         chalk.green('destination'),
-        chalk.green('amount (drops)'),
-        chalk.green('balance (drops)'),
+        chalk.green('amount (1E' + String(scale * -1) + 'XRP)'),
+        chalk.green('balance (1E' + String(scale * -1) + 'XRP)'),
         chalk.green('expiry') ],
-      ...channels.map(formatChannelToRow)
+      ...channels.map(
+        function(c, i) {
+          return formatChannelToRow(c, i, scale)
+        })
     ]))
   }
 
@@ -248,13 +253,16 @@ function formatChannelExpiration (exp) {
   return chalk.yellow('in ' + moment.duration(unixExp - Date.now()).humanize())
 }
 
-function formatChannelToRow (c, i) {
+function formatChannelToRow (c, i, s) {
+  const scaled_amount = c.amount * (10 ** (s - 6)) // base scale is drops (1E-6)
+  const scaled_balance = c.balance * (10 ** (s - 6))
+
   return [
     String(i),
     c.channel_id.substring(0, 8) + '...',
     c.destination_account,
-    comma(c.amount),
-    comma(c.balance),
+    comma(String(scaled_amount)),
+    comma(String(scaled_balance)),
     formatChannelExpiration(c.expiration)
   ]
 }


### PR DESCRIPTION
**feat: report channel details in correct asset scale**


Example: current network defaults use asset scale 9 (whereas drops are asset scale 6), so if I run `ilp-spsp send --amount 1000000 --receiver '$xxx'` my resulting balance will be increased by 1,000 (not 1,000,000). At no point in the default workflow is this information conveyed to the user.

```
index  channel id   destination   amount (drops)    balance (drops)     expiry
0      xx...        xx...         10,000,000        21,000
```

In this PR I propose we reflect the user's configured asset scale in the `moneyd xrp:info` and similar reports to avoid such confusion. For example, an asset scale of 9 would result in the following display:

```
index  channel id   destination   amount (1E-9XRP)  balance (1E-9XRP)   expiry
0      xx...        xx...         10,000,000,000    21,000,000
```

One thing I would like to be sure of in review is that this does not behave improperly when running multiple moneyd instances with different config files (and different asset scales) on the same machine. Any other bits of feedback welcome too.

Also, the moneyd [README](https://github.com/interledgerjs/moneyd/blob/master/README.md) says the command `moneyd xrp:topup --amount 1000` will topup 1000 drops regardless of asset scale. This is a further source of confusion. However, `xrp:topup` appears to have no effect currently - so asset scale issues are probably not the most pressing. That being said, it's likely worth investigating which other areas of the code might be exhibiting the same confusing behaviour addressed in this PR.

If some are identified, I would be happy to add more fixes before merging.