### PR TITLE
Add testnet connector test.styra-1b

### DIFF
--- a/connector_list.json
+++ b/connector_list.json
@@ -14,6 +14,7 @@
     "ilsp1.phobosnode.com"
   ],
   "test": [
-    "strata-ilsp.com/testnet/xrp"
+    "strata-ilsp.com/testnet/xrp",
+    "test.styra.network/1b/xrp"
   ]
 }


### PR DESCRIPTION
To support the onboarding process for new ILP developers and users, I'd like to add an additional testnet connector: test.styra-1b reachable via test.styra.network/1b/xrp