### PR TITLE
Make Phobosnode the default connector instead of strata

### DIFF
--- a/connector_list.json
+++ b/connector_list.json
@@ -1,6 +1,6 @@
 {
   "live": [
-    "strata-ilsp.com/xrp"
+    "ilsp1.phobosnode.com/moneyd"
   ],
   "old": [
     "btp.connector0.com",
@@ -10,7 +10,7 @@
     "client.scyl.la",
     "ilp.worldconnector.link",
     "ilp1.internetofvalue.xyz",
-    "ilsp1.phobosnode.com"
+    "strata-ilsp.com/xrp"
   ],
   "test": [
     "strata-ilsp.com/testnet/xrp",


### PR DESCRIPTION
Strata labs recently left the open network. This causes everyone who doesn't have an established relationship with strata to be unable to connect to their connector (400s from a websocket). These issues are documented [here](https://github.com/interledgerjs/moneyd/issues/109) and [here](https://forum.interledger.org/t/send-money-to-xrptipbot-with-moneyd-and-ilp-spsp/705) 

The workaround is to connect to a different connector. I tested and was successful connecting to phobosnode. However, all services hosted on strata infra are inaccessible.

The default configs of the ILP are no longer open due to strata's decision. This is a bad UX for new developers who follow instructions to the T and still can't use the network. I propose that the default connector should be an open connector instead of a closed connector. Since I tested with phobosnode and was successful in doing that, I propose we make phobosnode the default connector.